### PR TITLE
Add support for numbers in module names

### DIFF
--- a/flake8_module_name.py
+++ b/flake8_module_name.py
@@ -3,7 +3,7 @@ import re
 
 __version__ = "0.1.5"
 
-PATTERN = "[^a-z_]"
+PATTERN = "[^0-9a-z_]"
 
 search = re.compile(PATTERN).search
 

--- a/test_flake8_module_name.py
+++ b/test_flake8_module_name.py
@@ -9,13 +9,17 @@ from flake8_module_name import ModuleNameChecker
 from flake8_module_name import valid_pep8_filename
 
 
-@pytest.mark.parametrize("filename,result", [("module", True), ("MODULE", False)])
+@pytest.mark.parametrize("filename,result", [("module", True),
+                                             ("module123", True),
+                                             ("MODULE", False)
+                                             ])
 def test_valid_pep8_filename(filename, result):
     assert result == valid_pep8_filename(filename)
 
 
 @pytest.mark.parametrize("module_name,result", [("my_module.py", 0),
                                                 ("my_module/__init__.py", 0),
+                                                ("my_module/123_module.py", 0),
                                                 ("MYMODULE/__init__.py", 1),
                                                 ("MYMODULE.py", 1),
                                                 ])


### PR DESCRIPTION
Numbers in module names like `my_module_1.py` were generating false negatives. This PR fixes that.